### PR TITLE
Fix code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -134,5 +134,8 @@
     "vm-browserify": "^1.1.2",
     "whatwg-url": "^13.0.0",
     "ws": "^8.16.0"
+  },
+  "dependencies": {
+    "express-rate-limit": "^7.4.1"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/akaday/compass/security/code-scanning/7](https://github.com/akaday/compass/security/code-scanning/7)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Set up a rate limiter with appropriate configuration (e.g., maximum number of requests per time window).
3. Apply the rate limiter to the relevant endpoints (`/authenticate`, `/logout`, `/x509`, `/projectId`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
