### PR TITLE
Fix code scanning alert no. 2: Regular expression injection

### DIFF
--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -333,8 +333,9 @@ class Target {
     /**
      * Remove `.` from version tags for NUGET version
      */
+    const safeChannel = _.escapeRegExp(this.channel);
     const nuggetVersion = this.version.replace(
-      new RegExp(`-${this.channel}\\.(\\d+)`),
+      new RegExp(`-${safeChannel}\\.(\\d+)`),
       `-${this.channel}$1`
     );
 


### PR DESCRIPTION
Fixes [https://github.com/akaday/compass/security/code-scanning/2](https://github.com/akaday/compass/security/code-scanning/2)

To fix the problem, we need to sanitize the `this.channel` value before using it to construct the regular expression. We can use the `_.escapeRegExp` function from the lodash library to escape any special characters in `this.channel`. This will ensure that the regular expression behaves as expected and is not vulnerable to injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
