### PR TITLE
Fix code scanning alert no. 10: Information exposure through a stack trace

### DIFF
--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -378,7 +378,8 @@ expressProxy.use('/authenticate', limiter, async (req, res) => {
     res.send(JSON.stringify({ projectId }));
   } catch (err) {
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    console.error("Exception occurred:", err.stack);
+    res.send("An internal server error occurred");
   }
   res.end();
 });
@@ -409,7 +410,8 @@ expressProxy.use('/x509', limiter, async (req, res) => {
     res.send(cert);
   } catch (err) {
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    console.error("Exception occurred:", err.stack);
+    res.send("An internal server error occurred");
   }
   res.end();
 });
@@ -431,7 +433,8 @@ expressProxy.use('/projectId', limiter, async (req, res) => {
     }
   } catch (err) {
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    console.error("Exception occurred:", err.stack);
+    res.send("An internal server error occurred");
   }
   res.end();
 });


### PR DESCRIPTION
Fixes [https://github.com/akaday/compass/security/code-scanning/10](https://github.com/akaday/compass/security/code-scanning/10)

To fix the problem, we need to ensure that stack traces are not sent to the client. Instead, we should log the stack trace on the server and send a generic error message to the client. This can be achieved by replacing the lines that send `err.stack ?? err.message` with a generic error message and adding a logging mechanism for the stack trace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
