### PR TITLE
Fix code scanning alert no. 1: Unsafe shell command constructed from library input

### DIFF
--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -111,7 +111,6 @@ export class CompassAuthService {
       // internal plugin auth state), we copy oidc-plugin `openBrowser.command`
       // option handling to our openExternal method
       const child = spawn(browserCommandForOIDCAuth, [url], {
-        shell: true,
         stdio: 'ignore',
         detached: true,
       });


### PR DESCRIPTION
Fixes [https://github.com/akaday/compass/security/code-scanning/1](https://github.com/akaday/compass/security/code-scanning/1)

To fix the problem, we should avoid using the `shell: true` option in the `spawn` function and instead pass the command and its arguments as an array to the `spawn` function. This approach prevents the shell from interpreting special characters in the `url` parameter.

- Replace the `spawn` function call with `spawn(browserCommandForOIDCAuth, [url])` without the `shell: true` option.
- Ensure that the `url` parameter is passed as an argument to the command without shell interpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
