### PR TITLE
Fix code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -401,8 +401,9 @@ expressProxy.use('/x509', async (req, res) => {
     res.setHeader('Content-Type', 'text/plain');
     res.send(cert);
   } catch (err) {
+    console.error("Error in /x509 route:", err.stack ?? err.message);
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    res.send("An internal server error occurred.");
   }
   res.end();
 });
@@ -423,8 +424,9 @@ expressProxy.use('/projectId', async (req, res) => {
       res.send(projectId);
     }
   } catch (err) {
+    console.error("Error in /projectId route:", err.stack ?? err.message);
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    res.send("An internal server error occurred.");
   }
   res.end();
 });


### PR DESCRIPTION
Fixes [https://github.com/akaday/compass/security/code-scanning/5](https://github.com/akaday/compass/security/code-scanning/5)

To fix the problem, we need to ensure that stack traces and detailed error messages are not sent to the client. Instead, we should log the error details on the server and send a generic error message to the client. This can be achieved by modifying the error handling code to log the error and send a generic message.

- Modify the error handling code in the `/x509` and `/projectId` routes to log the error details and send a generic error message to the client.
- Add a logging mechanism to log the error details on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
